### PR TITLE
Consts and jetton dust fix

### DIFF
--- a/contracts/amm-minter-utils.fc
+++ b/contracts/amm-minter-utils.fc
@@ -70,7 +70,7 @@ int get_amount_out(int amountIn, int reserveIn, int reserveOut) method_id {
     int trgt_resvers = is_ton_src == true ? token_reserves : ton_reserves;  
     int amount_out = get_amount_out( transferd_amount, src_resvers, trgt_resvers);
     
-    ;; siplage is to low or insfuiccent amount , sending back the funds to sender minus gas
+    ;; Slippage is to low or insufficient amount, sending back the funds to sender minus gas
     if( (amount_out < min_amount_out) | (amount_out > trgt_resvers) ) {
         if is_ton_src == true {
             send_grams(swap_sender, transferd_amount);
@@ -95,38 +95,34 @@ int get_amount_out(int amountIn, int reserveIn, int reserveOut) method_id {
 
 
 () revert_add_liquidity(int ton_liquidity, int token_liquidity, slice token_wallet_address, slice jetton_sender, int query_id, int msg_value) impure {
-    ;; AG can this be merged into one message with forwarding ton facility?
+    ;; TODO This can potentially be merged into one message with forwarding ton facility?
     send_grams(jetton_sender, ton_liquidity);
     send_transfer_token_message(query_id, token_wallet_address, jetton_sender, token_liquidity, msg_value);
 }
 
 (int, int, int, int) mint_lp(int ton_amount, int token_amount, int ton_reserves, int token_reserves, int total_lp_supply) impure {
     
-    ;; AG this is actually lp amount
-    int new_liquidity = 0;
+    int lp_amount_to_mint = 0;
     int MINIMUM_LIQUIDITY = 1; ;; TODO IT SHOULD BE 1000 
-    ;; AG Why this should be 1000 ?
 
     ;; TODO fix handle liquidtiy supply on its own param
-    ;; AG initialize when there is not LP yet
+    ;; initialize when there is not LP yet
     if( token_reserves == 0 ) {
       ;; calc the user share  Sushi (Math.sqrt(amount0.mul(amount1)).sub(MINIMUM_LIQUIDITY);)
-      new_liquidity = squareRoot(ton_amount * token_amount) / MINIMUM_LIQUIDITY;
+      lp_amount_to_mint = squareRoot(ton_amount * token_amount) / MINIMUM_LIQUIDITY;
     } else {
       ;; liquidity = Math.min(amount0.mul(_totalSupply) / _reserve0, amount1.mul(_totalSupply) / _reserve1);
-      int ton_share = (ton_amount * total_lp_supply) / ton_reserves;
-      ;; AG shouldn't be using muldiv to avoid overflow?
-      ;; AG share is total_lp_supply * (ton_amount / ton_reserves)
-      int token_share = (token_amount * total_lp_supply) / token_reserves;
-      ;; AG can avoid having this calc and min() by using the optimal ton/jetton values that calculated before.
-      new_liquidity = min(ton_share, token_share);
+      int ton_share = total_lp_supply * (ton_amount / ton_reserves);
+      ;; TODO use muldiv to avoid overflow?
+      int token_share = total_lp_supply * (token_amount / token_reserves);
+      ;; TODO can avoid having this calc and min() by using the optimal ton/jetton values that calculated before.
+      lp_amount_to_mint = min(ton_share, token_share);
     }
 
-    ;; AG replace with += for consistency
-    token_reserves = token_amount + token_reserves;
-    ton_reserves = ton_amount + ton_reserves;
-    total_lp_supply = new_liquidity + total_lp_supply;    
-    return (new_liquidity, total_lp_supply, ton_reserves, token_reserves);
+    token_reserves += token_amount;
+    ton_reserves += ton_amount;
+    total_lp_supply += lp_amount_to_mint;    
+    return (lp_amount_to_mint, total_lp_supply, ton_reserves, token_reserves);
  }
 
 

--- a/contracts/amm-minter-utils.fc
+++ b/contracts/amm-minter-utils.fc
@@ -95,26 +95,34 @@ int get_amount_out(int amountIn, int reserveIn, int reserveOut) method_id {
 
 
 () revert_add_liquidity(int ton_liquidity, int token_liquidity, slice token_wallet_address, slice jetton_sender, int query_id, int msg_value) impure {
+    ;; AG can this be merged into one message with forwarding ton facility?
     send_grams(jetton_sender, ton_liquidity);
     send_transfer_token_message(query_id, token_wallet_address, jetton_sender, token_liquidity, msg_value);
 }
 
 (int, int, int, int) mint_lp(int ton_amount, int token_amount, int ton_reserves, int token_reserves, int total_lp_supply) impure {
     
+    ;; AG this is actually lp amount
     int new_liquidity = 0;
     int MINIMUM_LIQUIDITY = 1; ;; TODO IT SHOULD BE 1000 
+    ;; AG Why this should be 1000 ?
 
     ;; TODO fix handle liquidtiy supply on its own param
+    ;; AG initialize when there is not LP yet
     if( token_reserves == 0 ) {
       ;; calc the user share  Sushi (Math.sqrt(amount0.mul(amount1)).sub(MINIMUM_LIQUIDITY);)
       new_liquidity = squareRoot(ton_amount * token_amount) / MINIMUM_LIQUIDITY;
     } else {
       ;; liquidity = Math.min(amount0.mul(_totalSupply) / _reserve0, amount1.mul(_totalSupply) / _reserve1);
       int ton_share = (ton_amount * total_lp_supply) / ton_reserves;
+      ;; AG shouldn't be using muldiv to avoid overflow?
+      ;; AG share is total_lp_supply * (ton_amount / ton_reserves)
       int token_share = (token_amount * total_lp_supply) / token_reserves;
+      ;; AG can avoid having this calc and min() by using the optimal ton/jetton values that calculated before.
       new_liquidity = min(ton_share, token_share);
     }
 
+    ;; AG replace with += for consistency
     token_reserves = token_amount + token_reserves;
     ton_reserves = ton_amount + ton_reserves;
     total_lp_supply = new_liquidity + total_lp_supply;    

--- a/contracts/amm-minter.fc
+++ b/contracts/amm-minter.fc
@@ -6,7 +6,9 @@
 
 int jetton_storage() asm "50000000 PUSHINT"; ;; 0.05 TON
 int add_liquidity_dust() asm "100000000 PUSHINT"; ;; 0.1 TON
+;; AG why this is represented using a function and not a const
 
+;; AG does this reflect the actual storage structure? we're missing *_reserves, jetton_->amm_
 ;; storage scheme
 ;; storage#_ total_supply:Coins token_wallet_address:MsgAddress content:^Cell jetton_wallet_code:^Cell = Storage;
 
@@ -28,6 +30,7 @@ int add_liquidity_dust() asm "100000000 PUSHINT"; ;; 0.1 TON
             .store_slice(token_wallet_address)
             .store_coins(ton_reserves)
             .store_coins(token_reserves)
+            ;; AG isn't this redundant? Does not match the load_data()
             .store_coins(total_supply)
             .store_ref(content)
             .store_ref(jetton_wallet_code)
@@ -36,6 +39,7 @@ int add_liquidity_dust() asm "100000000 PUSHINT"; ;; 0.1 TON
 }
 
 
+;; AG zerro?
 const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
 
 
@@ -58,10 +62,15 @@ const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
 
     (int total_supply, slice token_wallet_address, int ton_reserves, int token_reserves, cell content, cell jetton_wallet_code) = load_data();
 
+    ;; AG typo
     int slipage = in_msg_body~load_uint(32);
+    ;; AG load_grams? or load_coins?
     int ton_liquidity = in_msg_body~load_grams();
 
+    ;; AG should it used as uint or checked for jetton_amount >= 0?
+    ;; AG 0 == , slippage < 0?
     if (0 == jetton_amount) | (msg_value == 0) | slipage > 100 {
+        ;;  AG why not bouncing? can't it fulfill the same goal of reverting?
         revert_add_liquidity(ton_liquidity, jetton_amount, token_wallet_address, jetton_sender, query_id, msg_value);
         return ();
     }
@@ -73,23 +82,32 @@ const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
     int should_revert = 0;
 
     if ton_reserves > 0 {
+        ;; AG calculate optimal dT and dJ based for maintaining the price/ratio
+        ;; AG dT = dJ * [ T / J ]
+        ;; AG dJ = dT * [ J / T ]
         int optimal_ton = quote(jetton_amount, token_reserves, ton_reserves);
         int optimal_jetton = quote(ton_liquidity, ton_reserves, token_reserves);
 
+        ;; AG calculate the minimum accepted deal, taking into account the max slippage.
         int ton_liquidity_min = ton_liquidity * ( 100 - slipage ) / 100;
         int jeton_liquidity_min = jetton_amount * ( 100 - slipage ) / 100;
 
         if( ( optimal_ton <= ton_liquidity_min ) | (optimal_jetton <= jeton_liquidity_min) ) {
             revert_add_liquidity(ton_liquidity, jetton_amount, token_wallet_address, jetton_sender, query_id, msg_value);
+             ;; AG should return() here and skip the should_revert hack?
             should_revert = 1;
         } else {
             int extra_ton = ton_liquidity - optimal_ton;
             int extra_jeton = jetton_amount - optimal_jetton;
 
             ;; return extra's
+            ;; AG this looks like a bug, 0.1 margin in token might be reasonable as oppsed to 0.1 ton dust
+             ;; AG replace liquidity dust with quote of 0.1T in Jetton 
             if extra_jeton > add_liquidity_dust() {
+                ;; AG change 100,000,000 to a const
                 send_transfer_token_message(query_id, token_wallet_address, jetton_sender, extra_jeton, 100000000);  ;; TODO      
             }
+            ;; AG throw exception if both extras > 0
             if extra_ton > add_liquidity_dust() {
                 send_grams(jetton_sender ,extra_ton);
             }
@@ -99,6 +117,7 @@ const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
       return ();
     }
 
+    ;; AG bug: should be (ton_liqueidty - extra_ton) and (jetton_amount - extra_jeton)
     (int new_liquidity, total_supply, ton_reserves, token_reserves) = mint_lp(ton_liquidity ,jetton_amount ,ton_reserves, token_reserves, total_supply);
                                                                 ;;TODO should put null instead of payload
     ;; end wallet is expecting the amount and owner,
@@ -129,6 +148,7 @@ const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
     }
     slice cs = in_msg_full.begin_parse();
     int flags = cs~load_uint(4);
+      ;; AG ignore all bounced messages, why AMM can afford to ignore bounced messages?
     if (flags & 1) {
       return ();
     }
@@ -138,6 +158,7 @@ const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
     cs~skip_bits(1); ;; skip extracurrency collection
     cs~load_coins(); ;; skip ihr_fee
     int fwd_fee = cs~load_coins(); ;; we use message fwd_fee for estimation of forward_payload costs    
+    ;; AG I don't understand the mechanics/logic of the fwd_fees
 
     int op = in_msg_body~load_uint(32);
     int query_id = in_msg_body~load_uint(64);
@@ -190,6 +211,7 @@ const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
       ;;  if token_wallet_address != null && token_wallet_address != sender_address -> throw
       if (equal_slices(token_wallet_address, zerro_address) == false) & (equal_slices(token_wallet_address, sender_address) == false) {
         throw_if(76, true);
+        ;; AG why using throw_if and not throw_unless or throw_if(76, XX)?
       }
       
       int sub_op = in_msg_body~load_uint(32);

--- a/contracts/amm-minter.fc
+++ b/contracts/amm-minter.fc
@@ -4,13 +4,12 @@
 #include "amm-utils.fc";
 #include "amm-minter-utils.fc";
 
-int jetton_storage() asm "50000000 PUSHINT"; ;; 0.05 TON
-int add_liquidity_dust() asm "100000000 PUSHINT"; ;; 0.1 TON
-;; AG why this is represented using a function and not a const
+const MIN_TONS_FOR_STORAGE = 10000000; ;; 0.01 TON
+const RESERVE_TONS_FOR_STORAGE = 50000000; ;; 0.05 TON
+const LIQUIDITY_DUST = 100000000; ;; 0.1 TON
 
-;; AG does this reflect the actual storage structure? we're missing *_reserves, jetton_->amm_
 ;; storage scheme
-;; storage#_ total_supply:Coins token_wallet_address:MsgAddress content:^Cell jetton_wallet_code:^Cell = Storage;
+;; storage#_ total_supply:Coins token_wallet_address:MsgAddress ton_reserves:Coins token_reserves:Coins content:^Cell jetton_wallet_code:^Cell = Storage;
 
 (int, slice, int, int, cell, cell) load_data() inline {
   slice ds = get_data().begin_parse();
@@ -30,17 +29,13 @@ int add_liquidity_dust() asm "100000000 PUSHINT"; ;; 0.1 TON
             .store_slice(token_wallet_address)
             .store_coins(ton_reserves)
             .store_coins(token_reserves)
-            ;; AG isn't this redundant? Does not match the load_data()
-            .store_coins(total_supply)
             .store_ref(content)
             .store_ref(jetton_wallet_code)
            .end_cell()
           );
 }
 
-
-;; AG zerro?
-const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
+const zero_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
 
 
 () mint_tokens(slice to_address, cell jetton_wallet_code, int amount, cell master_msg, int ton_leftovers) impure {
@@ -62,54 +57,47 @@ const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
 
     (int total_supply, slice token_wallet_address, int ton_reserves, int token_reserves, cell content, cell jetton_wallet_code) = load_data();
 
-    ;; AG typo
-    int slipage = in_msg_body~load_uint(32);
-    ;; AG load_grams? or load_coins?
-    int ton_liquidity = in_msg_body~load_grams();
+    int slippage = in_msg_body~load_uint(32);
+    int ton_liquidity = in_msg_body~load_coins();
 
-    ;; AG should it used as uint or checked for jetton_amount >= 0?
-    ;; AG 0 == , slippage < 0?
-    if (0 == jetton_amount) | (msg_value == 0) | slipage > 100 {
-        ;;  AG why not bouncing? can't it fulfill the same goal of reverting?
+    if (0 == jetton_amount) | (0 == msg_value) | slippage > 100 {
         revert_add_liquidity(ton_liquidity, jetton_amount, token_wallet_address, jetton_sender, query_id, msg_value);
         return ();
     }
 
-    if (ton_liquidity <= msg_value - (fwd_fee + jetton_storage())) | ton_liquidity < add_liquidity_dust() {
+    if (ton_liquidity <= msg_value - (fwd_fee + RESERVE_TONS_FOR_STORAGE)) | ton_liquidity < LIQUIDITY_DUST {
         revert_add_liquidity(ton_liquidity, jetton_amount, token_wallet_address, jetton_sender, query_id, msg_value);
         return ();
     }
     int should_revert = 0;
 
     if ton_reserves > 0 {
-        ;; AG calculate optimal dT and dJ based for maintaining the price/ratio
-        ;; AG dT = dJ * [ T / J ]
-        ;; AG dJ = dT * [ J / T ]
+        int current_jetton_price_in_ton = token_reserves / ton_reserves;
+        ;; calculate optimal dT and dJ based for maintaining the price/ratio
+        ;; dT = dJ * [ T / J ]
+        ;; dJ = dT * [ J / T ]
         int optimal_ton = quote(jetton_amount, token_reserves, ton_reserves);
         int optimal_jetton = quote(ton_liquidity, ton_reserves, token_reserves);
 
-        ;; AG calculate the minimum accepted deal, taking into account the max slippage.
-        int ton_liquidity_min = ton_liquidity * ( 100 - slipage ) / 100;
-        int jeton_liquidity_min = jetton_amount * ( 100 - slipage ) / 100;
+        ;; calculate the minimum accepted deal, taking into account the max slippage.
+        int ton_liquidity_min = ton_liquidity * ( 100 - slippage ) / 100;
+        int jeton_liquidity_min = jetton_amount * ( 100 - slippage ) / 100;
 
         if( ( optimal_ton <= ton_liquidity_min ) | (optimal_jetton <= jeton_liquidity_min) ) {
             revert_add_liquidity(ton_liquidity, jetton_amount, token_wallet_address, jetton_sender, query_id, msg_value);
-             ;; AG should return() here and skip the should_revert hack?
             should_revert = 1;
         } else {
             int extra_ton = ton_liquidity - optimal_ton;
             int extra_jeton = jetton_amount - optimal_jetton;
 
-            ;; return extra's
-            ;; AG this looks like a bug, 0.1 margin in token might be reasonable as oppsed to 0.1 ton dust
-             ;; AG replace liquidity dust with quote of 0.1T in Jetton 
-            if extra_jeton > add_liquidity_dust() {
-                ;; AG change 100,000,000 to a const
-                send_transfer_token_message(query_id, token_wallet_address, jetton_sender, extra_jeton, 100000000);  ;; TODO      
+            ;; return extra's, if it larger than 0.1 TON
+            if extra_jeton * current_jetton_price_in_ton > LIQUIDITY_DUST {
+                send_transfer_token_message(query_id, token_wallet_address, jetton_sender, extra_jeton, LIQUIDITY_DUST);  ;; TODO      
             }
-            ;; AG throw exception if both extras > 0
-            if extra_ton > add_liquidity_dust() {
+            else {
+              if extra_ton > LIQUIDITY_DUST {
                 send_grams(jetton_sender ,extra_ton);
+              }
             }
         }
     }
@@ -117,7 +105,6 @@ const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
       return ();
     }
 
-    ;; AG bug: should be (ton_liqueidty - extra_ton) and (jetton_amount - extra_jeton)
     (int new_liquidity, total_supply, ton_reserves, token_reserves) = mint_lp(ton_liquidity ,jetton_amount ,ton_reserves, token_reserves, total_supply);
                                                                 ;;TODO should put null instead of payload
     ;; end wallet is expecting the amount and owner,
@@ -132,7 +119,7 @@ const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
     .end_cell();
 
     ;; token_wallet_address  Starts as zeroAddress, and the first add-liuditiy sets the Amm's jetton wallet address (token_wallet_address)
-    if equal_slices(token_wallet_address, zerro_address) {
+    if equal_slices(token_wallet_address, zero_address) {
         token_wallet_address = sender_address;
     }
 
@@ -148,7 +135,6 @@ const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
     }
     slice cs = in_msg_full.begin_parse();
     int flags = cs~load_uint(4);
-      ;; AG ignore all bounced messages, why AMM can afford to ignore bounced messages?
     if (flags & 1) {
       return ();
     }
@@ -158,7 +144,6 @@ const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
     cs~skip_bits(1); ;; skip extracurrency collection
     cs~load_coins(); ;; skip ihr_fee
     int fwd_fee = cs~load_coins(); ;; we use message fwd_fee for estimation of forward_payload costs    
-    ;; AG I don't understand the mechanics/logic of the fwd_fees
 
     int op = in_msg_body~load_uint(32);
     int query_id = in_msg_body~load_uint(64);
@@ -188,7 +173,7 @@ const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
         int min_amount_out = in_msg_body~load_coins();
         throw_if(600, min_amount_out > token_reserves); ;;insufficent liquidity
         throw_if(601, 0 == token_reserves); ;; insufficent liquidity
-        throw_if(602, equal_slices(token_wallet_address, zerro_address) ); ;; pool is not intialized 
+        throw_if(602, equal_slices(token_wallet_address, zero_address) ); ;; pool is not intialized 
         
         (ton_reserves, token_reserves) = swapTokens(min_amount_out, ton_to_swap, true, sender_address, ton_reserves, token_reserves, token_wallet_address, query_id, msg_value);
         save_data(total_supply, token_wallet_address, ton_reserves, token_reserves, content, jetton_wallet_code);
@@ -209,9 +194,8 @@ const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
 
       ;; accept add-liquidity and swap actions only from token_wallet_address
       ;;  if token_wallet_address != null && token_wallet_address != sender_address -> throw
-      if (equal_slices(token_wallet_address, zerro_address) == false) & (equal_slices(token_wallet_address, sender_address) == false) {
+      if (equal_slices(token_wallet_address, zero_address) == false) & (equal_slices(token_wallet_address, sender_address) == false) {
         throw_if(76, true);
-        ;; AG why using throw_if and not throw_unless or throw_if(76, XX)?
       }
       
       int sub_op = in_msg_body~load_uint(32);
@@ -223,8 +207,8 @@ const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
 
       if (sub_op == OP_SWAP_TOKEN ) {  ;; swap TRC20 -> TON
           ;; bonuce message will be handled properly by the jetton sender
-          throw_if(75, equal_slices(token_wallet_address, zerro_address));
-          int min_amount_out = in_msg_body~load_grams();
+          throw_if(75, equal_slices(token_wallet_address, zero_address));
+          int min_amount_out = in_msg_body~load_coins();
           (ton_reserves, token_reserves) = swapTokens(min_amount_out, jetton_amount, false, jetton_sender, ton_reserves, token_reserves, token_wallet_address, query_id, msg_value);
           save_data(total_supply, token_wallet_address, ton_reserves, token_reserves, content, jetton_wallet_code);
           return ();
@@ -235,9 +219,6 @@ const zerro_address = "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c"a;
 
     throw(0xffff);
 }
-
-
-
 
 (int, int, slice, int, int, cell, cell) get_jetton_data() method_id {
     (int total_supply, slice token_wallet_address, int ton_reserves, int token_reserves, cell content, cell jetton_wallet_code) = load_data();

--- a/contracts/amm-wallet.fc
+++ b/contracts/amm-wallet.fc
@@ -3,8 +3,8 @@
 #include "params.fc";
 #include "amm-utils.fc";
 
-int min_tons_for_storage() asm "10000000 PUSHINT"; ;; 0.01 TON
-int gas_consumption() asm "10000000 PUSHINT"; ;; 0.01 TON
+const MIN_TONS_FOR_STORAGE = 10000000; ;; 0.01 TON
+const GAS_CONSUMPTION = 10000000; ;; 0.01 TON
 
 {-
   Storage
@@ -71,7 +71,7 @@ int gas_consumption() asm "10000000 PUSHINT"; ;; 0.01 TON
                      ;; 3 messages: wal1->wal2,  wal2->owner, wal2->response
                      ;; but last one is optional (it is ok if it fails)
                      2 * fwd_fee +
-                     (2 * gas_consumption() + min_tons_for_storage()));
+                     (2 * GAS_CONSUMPTION + MIN_TONS_FOR_STORAGE));
                      ;; universal message send fee calculation may be activated here
                      ;; by using this instead of fwd_fee
                      ;; msg_fwd_fee(to_wallet, msg_body, state_init, 15)
@@ -105,7 +105,7 @@ int gas_consumption() asm "10000000 PUSHINT"; ;; 0.01 TON
 
   int forward_ton_amount = in_msg_body~load_coins();
 
-  msg_value -= gas_consumption();
+  msg_value -= GAS_CONSUMPTION;
   if(forward_ton_amount) {
     msg_value -= forward_ton_amount + fwd_fee;
     slice either_forward_payload = in_msg_body;
@@ -129,7 +129,7 @@ int gas_consumption() asm "10000000 PUSHINT"; ;; 0.01 TON
   }
 
   if ((response_address.preload_uint(2) != 0) & (msg_value > 0)) {
-    raw_reserve(min_tons_for_storage(), 2);
+    raw_reserve(MIN_TONS_FOR_STORAGE, 2);
     var msg = begin_cell()
       .store_uint(0x10, 6) ;; nobounce - int_msg_info$0 ihr_disabled:Bool bounce:Bool bounced:Bool src:MsgAddress -> 011000
       .store_slice(response_address)
@@ -156,7 +156,7 @@ int gas_consumption() asm "10000000 PUSHINT"; ;; 0.01 TON
   throw_unless(705, equal_slices(owner_address, sender_address));
   throw_unless(706, balance >= 0);
   ;; TODO should be 3x fwd_fee ?
-  throw_unless(707, msg_value > (fwd_fee * 2) + (2 * gas_consumption()) );
+  throw_unless(707, msg_value > (fwd_fee * 2) + (2 * GAS_CONSUMPTION) );
 
   var msg_body = begin_cell()
       .store_uint(OP_BURN_NOTIFICAITON, 32)

--- a/contracts/jetton-minter.fc
+++ b/contracts/jetton-minter.fc
@@ -65,6 +65,9 @@
         master_msg_cs~skip_bits(32 + 64); ;; op + query_id
         int jetton_amount = master_msg_cs~load_coins();
         mint_tokens(to_address, jetton_wallet_code, amount, master_msg);
+        ;; AG What is content?
+        ;; AG What is master_msg?
+        ;; AG What is amount != jetton_amount
         save_data(total_supply + jetton_amount, admin_address, content, jetton_wallet_code);
         return ();
     }
@@ -77,11 +80,13 @@
         );
         save_data(total_supply - jetton_amount, admin_address, content, jetton_wallet_code);
         slice response_address = in_msg_body~load_msg_addr();
+        ;; AG What does this mechanism for?
         if (response_address.preload_uint(2) != 0) {
           var msg = begin_cell()
             .store_uint(0x10, 6) ;; nobounce - int_msg_info$0 ihr_disabled:Bool bounce:Bool bounced:Bool src:MsgAddress -> 011000
             .store_slice(response_address)
             .store_coins(0)
+            ;; AG What does this represent?
             .store_uint(0, 1 + 4 + 4 + 64 + 32 + 1 + 1)
             .store_uint(OP_EXCESSES, 32)
             .store_uint(query_id, 64);

--- a/contracts/jetton-wallet.fc
+++ b/contracts/jetton-wallet.fc
@@ -3,8 +3,8 @@
 #include "op-codes.fc";
 #include "jetton-utils.fc";
 
-int min_tons_for_storage() asm "10000000 PUSHINT"; ;; 0.01 TON
-int gas_consumption() asm "10000000 PUSHINT"; ;; 0.01 TON
+const MIN_TONS_FOR_STORAGE = 10000000; ;; 0.01 TON
+const GAS_CONSUMPTION = 10000000; ;; 0.01 TON
 
 {-
   Storage
@@ -43,32 +43,32 @@ int gas_consumption() asm "10000000 PUSHINT"; ;; 0.01 TON
   
   throw_unless(705, equal_slices(owner_address, sender_address));
   throw_unless(706, balance >= 0);
-  ;; AG about storage? why not throwing here?
 
   cell state_init = calculate_jetton_wallet_state_init(to_owner_address, jetton_master_address, jetton_wallet_code);
   slice to_wallet_address = calculate_jetton_wallet_address(state_init);
   slice response_address = in_msg_body~load_msg_addr();
   cell custom_payload = in_msg_body~load_dict();
+  ;; specifies the ton amount to forward (e.g for add liquidity)
   int forward_ton_amount = in_msg_body~load_coins();
-  ;; AG better naming?
+  ;; TODO better naming?
   slice either_forward_payload = in_msg_body;
   
   var msg = begin_cell()
     .store_uint(0x18, 6)
     .store_slice(to_wallet_address)
     .store_coins(0)
+    ;; (108, size in bits), 108 is for additional cell ref
     .store_uint(4 + 2 + 1, 1 + 4 + 4 + 64 + 32 + 1 + 1 + 1)
     .store_ref(state_init);
   var msg_body = begin_cell()
     .store_uint(OP_INTERNAL_TRANSFER, 32)
     .store_uint(query_id, 64)
     .store_coins(jetton_amount)
-     ;; AG set as the Sender (from)
+     ;; set as the Sender (from)
     .store_slice(owner_address)
-     ;; AG ???
+     ;; Excesses target
     .store_slice(response_address)
     .store_coins(forward_ton_amount)
-     ;; AG ???
     .store_slice(either_forward_payload)
     .end_cell();
 
@@ -78,7 +78,7 @@ int gas_consumption() asm "10000000 PUSHINT"; ;; 0.01 TON
                      ;; 3 messages: wal1->wal2,  wal2->owner2, wal2->response
                      ;; but last one is optional (it is ok if it fails)
                      2 * fwd_fee +
-                     (2 * gas_consumption() + min_tons_for_storage()));
+                     (2 * GAS_CONSUMPTION + MIN_TONS_FOR_STORAGE));
                      ;; universal message send fee calculation may be activated here
                      ;; by using this instead of fwd_fee
                      ;; msg_fwd_fee(to_wallet, msg_body, state_init, 15)
@@ -114,7 +114,7 @@ int gas_consumption() asm "10000000 PUSHINT"; ;; 0.01 TON
  );
   int forward_ton_amount = in_msg_body~load_coins();
 
-  msg_value -= gas_consumption();
+  msg_value -= GAS_CONSUMPTION;
   if(forward_ton_amount) {
     ;; AG how the fwd fee is calculated?
     msg_value -= forward_ton_amount + fwd_fee;
@@ -141,7 +141,7 @@ int gas_consumption() asm "10000000 PUSHINT"; ;; 0.01 TON
 
 ;; AG send ton excesses to the specified address (respone_address)
   if ((response_address.preload_uint(2) != 0) & (msg_value > 0)) {
-    raw_reserve(min_tons_for_storage(), 2);
+    raw_reserve(MIN_TONS_FOR_STORAGE, 2);
     var msg = begin_cell()
       .store_uint(0x10, 6) ;; nobounce - int_msg_info$0 ihr_disabled:Bool bounce:Bool bounced:Bool src:MsgAddress -> 011000
       .store_slice(response_address)
@@ -168,7 +168,7 @@ int gas_consumption() asm "10000000 PUSHINT"; ;; 0.01 TON
   
   throw_unless(705, equal_slices(owner_address, sender_address));
   throw_unless(706, balance >= 0);
-  throw_unless(707, msg_value > fwd_fee + 2 * gas_consumption());
+  throw_unless(707, msg_value > fwd_fee + 2 * GAS_CONSUMPTION);
 
   var msg_body = begin_cell()
       .store_uint(OP_BURN_NOTIFICAITON, 32)

--- a/contracts/jetton-wallet.fc
+++ b/contracts/jetton-wallet.fc
@@ -43,12 +43,14 @@ int gas_consumption() asm "10000000 PUSHINT"; ;; 0.01 TON
   
   throw_unless(705, equal_slices(owner_address, sender_address));
   throw_unless(706, balance >= 0);
+  ;; AG about storage? why not throwing here?
 
   cell state_init = calculate_jetton_wallet_state_init(to_owner_address, jetton_master_address, jetton_wallet_code);
   slice to_wallet_address = calculate_jetton_wallet_address(state_init);
   slice response_address = in_msg_body~load_msg_addr();
   cell custom_payload = in_msg_body~load_dict();
   int forward_ton_amount = in_msg_body~load_coins();
+  ;; AG better naming?
   slice either_forward_payload = in_msg_body;
   
   var msg = begin_cell()
@@ -61,16 +63,19 @@ int gas_consumption() asm "10000000 PUSHINT"; ;; 0.01 TON
     .store_uint(OP_INTERNAL_TRANSFER, 32)
     .store_uint(query_id, 64)
     .store_coins(jetton_amount)
+     ;; AG set as the Sender (from)
     .store_slice(owner_address)
+     ;; AG ???
     .store_slice(response_address)
     .store_coins(forward_ton_amount)
+     ;; AG ???
     .store_slice(either_forward_payload)
     .end_cell();
 
   msg = msg.store_ref(msg_body);
   throw_unless(709, msg_value >
                      forward_ton_amount +
-                     ;; 3 messages: wal1->wal2,  wal2->owner, wal2->response
+                     ;; 3 messages: wal1->wal2,  wal2->owner2, wal2->response
                      ;; but last one is optional (it is ok if it fails)
                      2 * fwd_fee +
                      (2 * gas_consumption() + min_tons_for_storage()));
@@ -102,18 +107,23 @@ int gas_consumption() asm "10000000 PUSHINT"; ;; 0.01 TON
  throw_unless(707,
      equal_slices(jetton_master_address, sender_address)
      |
+     ;; AG sender_address is the jetton wallet address of owner (where we got the message from)
+     ;; AG from_address is the owner address (specified in the message body)
+     ;; 
      equal_slices(calculate_user_jetton_wallet_address(from_address, jetton_master_address, jetton_wallet_code), sender_address)
  );
   int forward_ton_amount = in_msg_body~load_coins();
 
   msg_value -= gas_consumption();
   if(forward_ton_amount) {
+    ;; AG how the fwd fee is calculated?
     msg_value -= forward_ton_amount + fwd_fee;
     slice either_forward_payload = in_msg_body;
 
     var msg_body = begin_cell()
         .store_uint(OP_TRANSFER_NOTIFICATION, 32)
         .store_uint(query_id, 64)
+         ;; AG why jetton_amount is on the body, while the forward ton amount is in the header?
         .store_coins(jetton_amount)
         .store_slice(from_address)
         .store_slice(either_forward_payload)
@@ -129,6 +139,7 @@ int gas_consumption() asm "10000000 PUSHINT"; ;; 0.01 TON
     send_raw_message(msg.end_cell(), 1);
   }
 
+;; AG send ton excesses to the specified address (respone_address)
   if ((response_address.preload_uint(2) != 0) & (msg_value > 0)) {
     raw_reserve(min_tons_for_storage(), 2);
     var msg = begin_cell()

--- a/contracts/params.fc
+++ b/contracts/params.fc
@@ -1,5 +1,6 @@
 int workchain() asm "0 PUSHINT";
 
+;; AG Whould we enforce WC #0 or enfore the "current" WC, where this object is tied to?
 () force_chain(slice addr) impure {
   (int wc, _) = parse_std_addr(addr);
   throw_unless(333, wc == workchain());


### PR DESCRIPTION
- Moved storage and liquidity dust to consts.
- Fixed lp minter save_data overwrite bug.
- Fixed extra jetton return when jetton<0.1 .
- Migrated some of the calls from _grams to _coins.
- Multiple semantic updates for better readability.